### PR TITLE
Make delay completion test use a single variable.

### DIFF
--- a/src/Task.h
+++ b/src/Task.h
@@ -20,10 +20,8 @@ protected:
     virtual void loop() {}
 
     void delay(unsigned long ms) {
-        if (ms) {
-            delay_time = millis();
-            delay_ms = ms;
-        }
+        if (ms)
+            delay_done_ms = millis() + ms;
 
         yield();
     }
@@ -33,9 +31,7 @@ protected:
     }
 
     virtual bool shouldRun() {
-        unsigned long now = millis();
-
-        return !delay_ms || now >= delay_time + delay_ms;
+        return (millis() >= delay_done_ms);
     }
 
 private:
@@ -47,8 +43,7 @@ private:
     cont_t context;
 
     bool setup_done = false;
-    unsigned long delay_time;
-    unsigned long delay_ms;
+    unsigned long delay_done_ms = 1;
 
     void loopWrapper() {
         if (!setup_done) {


### PR DESCRIPTION
Hi there!

I thought I'd contribute this little snippet to make the delay_test a little more efficient.
Instead of capturing a "base time" and a "delay time" and adding them together each loop; this modification sets a "delay_done_ms" time up front (a target time after which the delay has finished) and then tests directly against that.

I also couldn't see what the (!delay_ms) was adding so I removed it. If it's actually required, then some equivalent can be put back.  Just in case having a non-zero value makes a difference to you; I went ahead and initialized delay_done_ms = 1.  (But that initialization can be safely removed.)

Cheers!