### PR TITLE
Make timer delay comparison test "rollover safe"

### DIFF
--- a/src/Scheduler.cpp
+++ b/src/Scheduler.cpp
@@ -10,6 +10,10 @@ SchedulerClass Scheduler;
 
 Task SchedulerClass::main;
 Task *SchedulerClass::current = &SchedulerClass::main;
+uint8_t SchedulerClass::nActiveGroupsIdx = 0;
+uint8_t SchedulerClass::nActiveTasks = 0;
+uint8_t SchedulerClass::scheduler_cycle_id = 0;
+uint8_t SchedulerClass::scheduler_run_group_id = 0;
 
 SchedulerClass::SchedulerClass() {
     main.next = &main;
@@ -24,14 +28,109 @@ void SchedulerClass::start(Task *task) {
     main.prev = task;
 }
 
+
+void SchedulerClass::updateCurrentTask() {
+	// This update runs before the call to shouldRun
+	uint8_t task_run_group_id = current->run_group_id;
+/*
+	Serial.print("Begin : "); 
+	Serial.print("\t SchedulerCycleID: "); Serial.print(scheduler_cycle_id); 
+	Serial.print("\t TaskCycleID: "); Serial.print(current->current_cycle_id);
+	Serial.print("\t SchedulerRunGroup: "); Serial.print(scheduler_run_group_id);
+	Serial.print("\t TaskRunGroup: "); Serial.print(task_run_group_id);
+	Serial.print("\t Complete: "); Serial.print(current->loop_complete);
+	Serial.println();
+*/
+	// First, check the cycle_id
+	if ( current->current_cycle_id != scheduler_cycle_id ) {
+        // If the Task's cycle_id doesn't match; reset loop_complete and set the current cycle_id
+        if (task_run_group_id != 0xFF) current->loop_complete = false;
+        current->current_cycle_id = scheduler_cycle_id;
+	}
+	
+	// Next, update the Task's run_group_active flag
+	// If this Task's run_group_id == 0xFF; run_group_active is true
+    current->run_group_active = (task_run_group_id == 0xFF) || (task_run_group_id == scheduler_run_group_id);
+/*
+	Serial.print("Finish: "); 
+	Serial.print("\t SchedulerCycleID: "); Serial.print(scheduler_cycle_id); 
+	Serial.print("\t TaskCycleID: "); Serial.print(current->current_cycle_id);
+	Serial.print("\t SchedulerRunGroup: "); Serial.print(scheduler_run_group_id);
+	Serial.print("\t TaskRunGroup: "); Serial.print(task_run_group_id);
+	Serial.print("\t Complete: "); Serial.print(current->loop_complete);
+	Serial.println();
+*/
+}
+
+void SchedulerClass::updateRunGroups() {
+	// This is called after the Task had a chance to run; updateCurrentTask() reset loop_complete and cycle_id if required
+	// and if part of the currently active run_group, loop() could have set loop_complete
+
+    // First, update the corresponding ActiveRunGroup bits
+	uint8_t task_run_group_id = current->run_group_id;
+	
+	// Mark the group bit idx as an active group
+	nActiveGroupsIdx |= (1 << task_run_group_id);  // This is cumulative, so any Task in the Group will set the bit
+		
+	// If this Task is !loop_complete and also part of the current run_group, increment nActiveTasks; this group_id isn't done yet
+	if (!current->loop_complete && scheduler_run_group_id == task_run_group_id) nActiveTasks++;
+
+	// Then, if a full loop through all the Tasks completed; update the run_group state
+	if (current->next == &main) {
+/*
+	Serial.print("Begin : "); 
+	//Serial.print("\t Complete: "); Serial.print(current->loop_complete);
+	Serial.print("\t nActiveTasks: "); Serial.print(nActiveTasks); 
+	Serial.print("\t nActiveGroupsIdx: 0x"); Serial.print(nActiveGroupsIdx, HEX);
+	Serial.print("\t scheduler_run_group_id: "); Serial.print(scheduler_run_group_id);
+	Serial.print("\t scheduler_cycle_id: "); Serial.print(scheduler_cycle_id);
+	Serial.println();
+*/
+		// If there were no GroupActiveTasks found (all loop_completed == false) for this group_id, move to the next group_id
+		if (nActiveTasks == 0) {
+			uint8_t nGroups = countRunGroups();
+
+			scheduler_run_group_id = (scheduler_run_group_id + 1) % nGroups;			
+			if (scheduler_run_group_id == 0) scheduler_cycle_id++;        // If group_id wrapped back to 0; a cycle completed
+		
+			// nActiveGroupsIdx is a bit flag array for Group IDs with Tasks assigned to them 
+			uint8_t nIncs = 0; //Infinite Loop Protector
+			while ( /*nActiveGroupsIdx != 0 && */(nActiveGroupsIdx & (1 << scheduler_run_group_id)) == 0 ) {
+				scheduler_run_group_id = (scheduler_run_group_id + 1) % nGroups;
+				if (scheduler_run_group_id == 0) scheduler_cycle_id++;    // If group_id wraps back to 0; the cycle completed
+				nIncs++;
+				if (nIncs >= nGroups - 1) break; // If the counter has Incremented a full rotation; stop.
+			}			
+			
+		}
+		nActiveTasks = 0;  		// reset count of GroupActiveTasks
+		nActiveGroupsIdx = 0;	// reset indeces of ActiveGroups
+/*
+	Serial.print("Finish: "); 
+	//Serial.print("\t Complete: "); Serial.print(current->loop_complete);
+	Serial.print("\t nActiveTasks: "); Serial.print(nActiveTasks); 
+	Serial.print("\t nActiveGroupsIdx: 0x"); Serial.print(nActiveGroupsIdx, HEX);
+	Serial.print("\t scheduler_run_group_id: "); Serial.print(scheduler_run_group_id);
+	Serial.print("\t scheduler_cycle_id: "); Serial.print(scheduler_cycle_id);
+	Serial.println();
+*/
+	}
+}
+
+
 void SchedulerClass::begin() {
     while (1) {
-        if (current->shouldRun())
+		
+		updateCurrentTask();
+		
+		if(current->shouldRun()) 
             cont_run(&current->context, task_tramponline);
-
+		
+		updateRunGroups();
+		
         yield();
-
-        current = current->next;
+		
+        current = current->next;		
     }
 }
 

--- a/src/Scheduler.h
+++ b/src/Scheduler.h
@@ -10,7 +10,14 @@ extern void task_tramponline();
 class SchedulerClass {
 public:
     SchedulerClass();
-
+	inline static uint8_t getCurrentRunGroupID() { return scheduler_run_group_id; }
+	inline static uint8_t getCurrentCycleID() { return scheduler_cycle_id; }
+    inline static uint8_t countRunGroups() { 
+	    return ((sizeof nActiveGroupsIdx) * 8); // The count of group ids is the number of bits in nActiveGroupsIdx
+    }
+    static void updateRunGroups();
+    static void updateCurrentTask();
+	
     static void start(Task *task);
 
     static void begin();
@@ -22,6 +29,11 @@ private:
 
     static Task main;
     static Task *current;
+
+    static uint8_t nActiveGroupsIdx;
+    static uint8_t nActiveTasks;
+    static uint8_t scheduler_cycle_id;
+    static uint8_t scheduler_run_group_id;
 };
 
 extern SchedulerClass Scheduler;

--- a/src/Task.h
+++ b/src/Task.h
@@ -21,7 +21,7 @@ protected:
 
     void delay(unsigned long ms) {
         if (ms) {
-            delay_time = millis();
+            delay_start = millis();
             delay_ms = ms;
         }
 
@@ -35,7 +35,8 @@ protected:
     virtual bool shouldRun() {
         unsigned long now = millis();
 
-        return !delay_ms || now >= delay_time + delay_ms;
+        // This comparison is "rollover safe"
+        return (now - delay_start) >= delay_ms; 
     }
 
 private:
@@ -47,8 +48,8 @@ private:
     cont_t context;
 
     bool setup_done = false;
-    unsigned long delay_time;
-    unsigned long delay_ms;
+    unsigned long delay_start = 0;
+    unsigned long delay_ms = 0;
 
     void loopWrapper() {
         if (!setup_done) {

--- a/src/Task.h
+++ b/src/Task.h
@@ -2,7 +2,7 @@
 #define TASK_H
 
 #include <Arduino.h>
-#include "Scheduler.h"
+//#include "Scheduler.h"
 
 extern "C" {
     #include "cont.h"
@@ -32,13 +32,32 @@ protected:
         cont_yield(&context);
     }
 
-    virtual bool shouldRun() {
+	inline bool isDelayed() {
+		return (delay_ms != 0);
+	}
+
+	void updateDelayTimer() {
+		if (delay_ms == 0) return;   // Optimize for the non-delayed case
+
+		// This comparison is "rollover safe"
         unsigned long now = millis();
+        if ((now - delay_start) >= delay_ms)
+			delay_ms = 0;
+	}
 
-        // This comparison is "rollover safe"
-        return (now - delay_start) >= delay_ms; 
-    }
+    virtual bool shouldRun() {
+		// Tasks update their own delay timer
+		updateDelayTimer();
+		if (isDelayed()) return false;
+        if (!run_group_active) return false;
+		return !loop_complete;
+	}
 
+    uint8_t current_cycle_id = 0;
+    uint8_t run_group_id = 0xFF;
+    bool run_group_active = false;
+	
+    bool loop_complete = false;
 private:
     friend class SchedulerClass;
     friend void task_tramponline();
@@ -46,6 +65,7 @@ private:
     Task *next;
     Task *prev;
     cont_t context;
+
 
     bool setup_done = false;
     unsigned long delay_start = 0;


### PR DESCRIPTION
I tweaked the math on the comparison test to make the delay test "rollover safe" which means delays crossing the ~49.7 days (assuming a 32-bit millis()) boundary will work correctly.