### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -7,13 +7,13 @@
 #######################################
 
 Scheduler	KEYWORD1
-Task        KEYWORD1
+Task	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-start       KEYWORD2
-begin       KEYWORD2
+start	KEYWORD2
+begin	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords