### PR TITLE
LeanTask

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ private:
 Tasks can run ```yield``` and ```delay``` like they normally would. These functions yield control to the scheduler
 rather than the ESP8266.
 
+**IMPORTANT: Each task consumes 4kb of ram.**
+
 ### Advanced Task Functions
 
 The ```Task``` also exposes a ```bool shouldRun()``` method that is used determine if the task loop
@@ -74,6 +76,36 @@ bool shouldRun() {
 
 **This function handles the ```delay()``` logic. The parent method should be called.**
 
+# Creating a LeanTask
+
+A ```LeanTask``` runs in the global context, so calling ```delay()```  inside one blocks execution for all tasks. The advantage of lean tasks is that they consume no extra RAM, so you can add as many as you wish.
+LeanTasks can run ```schedule(ms);``` to indicate to the scheduler, that the next iteration of their loop function should not run for the next `ms` milliseconds.
+
+If you have a ```Task``` that uses one single call to `delay(ms)` at the end of the loop, you can save 4k of ram by declaring it as a ```LeanTask``` instead and replacing `delay(ms)` with `schedule(ms)` call.
+
+```cpp
+class BlinkTask : public LeanTask {
+protected:
+    void setup() {
+        state = HIGH;
+
+        pinMode(2, OUTPUT);
+        pinMode(2, state);
+    }
+
+    void loop() {
+        state = state == HIGH ? LOW : HIGH;
+        pinMode(2, state);
+
+        schedule(1000);
+    }
+
+private:
+    uint8_t state;
+} blink_task;
+```
+
+
 # Documentation
 
 ## Methods
@@ -81,6 +113,7 @@ bool shouldRun() {
 ### start
 ```
 static void start(Task *task)
+static void start(LeanTask *leanTask)
 ```
 > Adds a task to the multitasking queue.
 

--- a/examples/simple/withLeanTasks.ino
+++ b/examples/simple/withLeanTasks.ino
@@ -1,0 +1,64 @@
+#include <Arduino.h>
+#include <Scheduler.h>
+
+class PrintTask : public Task {
+protected:
+    void loop()  {
+        Serial.println("Print Loop Start");
+
+        delay(5000);
+
+        Serial.println("Print Loop End");
+
+        delay(5000);
+    }
+} print_task;
+
+class BlinkLeanTask : public LeanTask {
+protected:
+    void setup() {
+        state = HIGH;
+
+        pinMode(2, OUTPUT);
+        pinMode(2, state);
+    }
+
+    void loop() {
+        state = state == HIGH ? LOW : HIGH;
+        pinMode(2, state);
+        // lean tasks don't have a delay, but they consume no extra ram
+        // use schedule(ms) anywhere in your loop to indicate that the next cycle of the loop
+        // should happen x milliseconds in the future 
+        schedule(1000);
+    }
+
+private:
+    uint8_t state;
+} blink_leanTask;
+
+class MemTask : public Task {
+public:
+    void loop() {
+        Serial.print("Free Heap: ");
+        Serial.print(ESP.getFreeHeap());
+        Serial.println(" bytes");
+
+        delay(10000);
+    }
+} mem_task;
+
+void setup() {
+    Serial.begin(115200);
+
+    Serial.println("");
+
+    delay(1000);
+
+    Scheduler.start(&print_task);
+    Scheduler.start(&blink_leanTask);
+    Scheduler.start(&mem_task);
+
+    Scheduler.begin();
+}
+
+void loop() {}

--- a/keywords.txt
+++ b/keywords.txt
@@ -8,12 +8,14 @@
 
 Scheduler	KEYWORD1
 Task	KEYWORD1
+LeanTask	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 start	KEYWORD2
 begin	KEYWORD2
+schedule	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)

--- a/src/Scheduler.cpp
+++ b/src/Scheduler.cpp
@@ -1,139 +1,32 @@
 #include "Scheduler.h"
 
 extern "C" {
-    #include "cont.h"
+#include "cont.h"
 
-    void yield();
+void yield();
 }
 
 SchedulerClass Scheduler;
+ITask *SchedulerClass::last = NULL;
+ITask *SchedulerClass::current = NULL;
+SchedulerClass::SchedulerClass() {}
 
-Task SchedulerClass::main;
-Task *SchedulerClass::current = &SchedulerClass::main;
-uint8_t SchedulerClass::nActiveGroupsIdx = 0;
-uint8_t SchedulerClass::nActiveTasks = 0;
-uint8_t SchedulerClass::scheduler_cycle_id = 0;
-uint8_t SchedulerClass::scheduler_run_group_id = 0;
-
-SchedulerClass::SchedulerClass() {
-    main.next = &main;
-    main.prev = &main;
+void SchedulerClass::start(ITask *task) {
+  if (!last) {
+    current = last = task;
+  } else {
+    last->next = task;
+    last = task;
+  }
 }
-
-void SchedulerClass::start(Task *task) {
-    task->next = &main;
-    task->prev = main.prev;
-
-    main.prev->next = task;
-    main.prev = task;
-}
-
-
-void SchedulerClass::updateCurrentTask() {
-	// This update runs before the call to shouldRun
-	uint8_t task_run_group_id = current->run_group_id;
-/*
-	Serial.print("Begin : "); 
-	Serial.print("\t SchedulerCycleID: "); Serial.print(scheduler_cycle_id); 
-	Serial.print("\t TaskCycleID: "); Serial.print(current->current_cycle_id);
-	Serial.print("\t SchedulerRunGroup: "); Serial.print(scheduler_run_group_id);
-	Serial.print("\t TaskRunGroup: "); Serial.print(task_run_group_id);
-	Serial.print("\t Complete: "); Serial.print(current->loop_complete);
-	Serial.println();
-*/
-	// First, check the cycle_id
-	if ( current->current_cycle_id != scheduler_cycle_id ) {
-        // If the Task's cycle_id doesn't match; reset loop_complete and set the current cycle_id
-        if (task_run_group_id != 0xFF) current->loop_complete = false;
-        current->current_cycle_id = scheduler_cycle_id;
-	}
-	
-	// Next, update the Task's run_group_active flag
-	// If this Task's run_group_id == 0xFF; run_group_active is true
-    current->run_group_active = (task_run_group_id == 0xFF) || (task_run_group_id == scheduler_run_group_id);
-/*
-	Serial.print("Finish: "); 
-	Serial.print("\t SchedulerCycleID: "); Serial.print(scheduler_cycle_id); 
-	Serial.print("\t TaskCycleID: "); Serial.print(current->current_cycle_id);
-	Serial.print("\t SchedulerRunGroup: "); Serial.print(scheduler_run_group_id);
-	Serial.print("\t TaskRunGroup: "); Serial.print(task_run_group_id);
-	Serial.print("\t Complete: "); Serial.print(current->loop_complete);
-	Serial.println();
-*/
-}
-
-void SchedulerClass::updateRunGroups() {
-	// This is called after the Task had a chance to run; updateCurrentTask() reset loop_complete and cycle_id if required
-	// and if part of the currently active run_group, loop() could have set loop_complete
-
-    // First, update the corresponding ActiveRunGroup bits
-	uint8_t task_run_group_id = current->run_group_id;
-	
-	// Mark the group bit idx as an active group
-	nActiveGroupsIdx |= (1 << task_run_group_id);  // This is cumulative, so any Task in the Group will set the bit
-		
-	// If this Task is !loop_complete and also part of the current run_group, increment nActiveTasks; this group_id isn't done yet
-	if (!current->loop_complete && scheduler_run_group_id == task_run_group_id) nActiveTasks++;
-
-	// Then, if a full loop through all the Tasks completed; update the run_group state
-	if (current->next == &main) {
-/*
-	Serial.print("Begin : "); 
-	//Serial.print("\t Complete: "); Serial.print(current->loop_complete);
-	Serial.print("\t nActiveTasks: "); Serial.print(nActiveTasks); 
-	Serial.print("\t nActiveGroupsIdx: 0x"); Serial.print(nActiveGroupsIdx, HEX);
-	Serial.print("\t scheduler_run_group_id: "); Serial.print(scheduler_run_group_id);
-	Serial.print("\t scheduler_cycle_id: "); Serial.print(scheduler_cycle_id);
-	Serial.println();
-*/
-		// If there were no GroupActiveTasks found (all loop_completed == false) for this group_id, move to the next group_id
-		if (nActiveTasks == 0) {
-			uint8_t nGroups = countRunGroups();
-
-			scheduler_run_group_id = (scheduler_run_group_id + 1) % nGroups;			
-			if (scheduler_run_group_id == 0) scheduler_cycle_id++;        // If group_id wrapped back to 0; a cycle completed
-		
-			// nActiveGroupsIdx is a bit flag array for Group IDs with Tasks assigned to them 
-			uint8_t nIncs = 0; //Infinite Loop Protector
-			while ( /*nActiveGroupsIdx != 0 && */(nActiveGroupsIdx & (1 << scheduler_run_group_id)) == 0 ) {
-				scheduler_run_group_id = (scheduler_run_group_id + 1) % nGroups;
-				if (scheduler_run_group_id == 0) scheduler_cycle_id++;    // If group_id wraps back to 0; the cycle completed
-				nIncs++;
-				if (nIncs >= nGroups - 1) break; // If the counter has Incremented a full rotation; stop.
-			}			
-			
-		}
-		nActiveTasks = 0;  		// reset count of GroupActiveTasks
-		nActiveGroupsIdx = 0;	// reset indeces of ActiveGroups
-/*
-	Serial.print("Finish: "); 
-	//Serial.print("\t Complete: "); Serial.print(current->loop_complete);
-	Serial.print("\t nActiveTasks: "); Serial.print(nActiveTasks); 
-	Serial.print("\t nActiveGroupsIdx: 0x"); Serial.print(nActiveGroupsIdx, HEX);
-	Serial.print("\t scheduler_run_group_id: "); Serial.print(scheduler_run_group_id);
-	Serial.print("\t scheduler_cycle_id: "); Serial.print(scheduler_cycle_id);
-	Serial.println();
-*/
-	}
-}
-
 
 void SchedulerClass::begin() {
-    while (1) {
-		
-		updateCurrentTask();
-		
-		if(current->shouldRun()) 
-            cont_run(&current->context, task_tramponline);
-		
-		updateRunGroups();
-		
-        yield();
-		
-        current = current->next;		
-    }
+  last->next = current;
+  while (1) {
+    current->resume();
+    yield();
+    current = current->next;
+  }
 }
 
-void task_tramponline() {
-    SchedulerClass::current->loopWrapper();
-}
+void task_tramponline() { ((Task *)SchedulerClass::current)->loopWrapper(); }

--- a/src/Scheduler.h
+++ b/src/Scheduler.h
@@ -1,41 +1,22 @@
 #ifndef SCHEDULER_H
 #define SCHEDULER_H
 
-// #include <Arduino.h>
 #include "Task.h"
 
 extern "C" void loop();
 extern void task_tramponline();
 
 class SchedulerClass {
-public:
-    SchedulerClass();
-	inline static uint8_t getCurrentRunGroupID() { return scheduler_run_group_id; }
-	inline static uint8_t getCurrentCycleID() { return scheduler_cycle_id; }
-    inline static uint8_t countRunGroups() { 
-	    return ((sizeof nActiveGroupsIdx) * 8); // The count of group ids is the number of bits in nActiveGroupsIdx
-    }
-    static void updateRunGroups();
-    static void updateCurrentTask();
-	
-    static void start(Task *task);
+ public:
+  SchedulerClass();
+  static void start(ITask *task);
+  static void begin();
 
-    static void begin();
-
-private:
-    friend void task_tramponline();
-
-    // class MainTask : public Task {};
-
-    static Task main;
-    static Task *current;
-
-    static uint8_t nActiveGroupsIdx;
-    static uint8_t nActiveTasks;
-    static uint8_t scheduler_cycle_id;
-    static uint8_t scheduler_run_group_id;
+ private:
+  friend void task_tramponline();
+  static ITask *last;
+  static ITask *current;
 };
-
 extern SchedulerClass Scheduler;
 
 #endif

--- a/src/Task.h
+++ b/src/Task.h
@@ -67,7 +67,7 @@ class LeanTask : public ITask {
 
  private:
   bool setup_done;
-  virtual void resume() {
+  void resume() {
     if (!setup_done) {
       setup();
       setup_done = true;

--- a/src/Task.h
+++ b/src/Task.h
@@ -2,86 +2,78 @@
 #define TASK_H
 
 #include <Arduino.h>
-//#include "Scheduler.h"
+
+#include "Scheduler.h"
 
 extern "C" {
-    #include "cont.h"
+#include "cont.h"
 }
+void task_tramponline();
+class ITask {
+ protected:
+  virtual void setup() {}
+  virtual void loop() {}
+  virtual bool shouldRun() {
+    unsigned long now = millis();
+    return !delay_ms || now >= delay_time + delay_ms;
+  }
 
-class Task {
-public:
-    Task() {
-        cont_init(&context);
+  unsigned long delay_time;
+  unsigned long delay_ms;
+
+ private:
+  friend class SchedulerClass;
+  virtual void resume() {}
+  ITask* next;
+};
+
+class Task : public ITask {
+ public:
+  Task() { cont_init(&context); }
+
+ protected:
+  void delay(unsigned long ms) {
+    if (ms) {
+      delay_time = millis();
+      delay_ms = ms;
     }
+    yield();
+  }
+  void yield() { cont_yield(&context); }
 
-protected:
-    virtual void setup() {}
+ private:
+  friend void task_tramponline();
+  cont_t context;
+  virtual void resume() {
+    if (shouldRun()) cont_run(&context, task_tramponline);
+  }
+  void loopWrapper() {
+    setup();
+    while (1) {
+      loop();
+      yield();
+    };
+  }
+};
 
-    virtual void loop() {}
-
-    void delay(unsigned long ms) {
-        if (ms) {
-            delay_start = millis();
-            delay_ms = ms;
-        }
-
-        yield();
+class LeanTask : public ITask {
+ protected:
+  void schedule(unsigned long ms) {
+    if (ms) {
+      delay_time = millis();
+      delay_ms = ms;
     }
+  }
 
-    void yield() {
-        cont_yield(&context);
-    }
-
-	inline bool isDelayed() {
-		return (delay_ms != 0);
-	}
-
-	void updateDelayTimer() {
-		if (delay_ms == 0) return;   // Optimize for the non-delayed case
-
-		// This comparison is "rollover safe"
-        unsigned long now = millis();
-        if ((now - delay_start) >= delay_ms)
-			delay_ms = 0;
-	}
-
-    virtual bool shouldRun() {
-		// Tasks update their own delay timer
-		updateDelayTimer();
-		if (isDelayed()) return false;
-        if (!run_group_active) return false;
-		return !loop_complete;
-	}
-
-    uint8_t current_cycle_id = 0;
-    uint8_t run_group_id = 0xFF;
-    bool run_group_active = false;
-	
-    bool loop_complete = false;
-private:
-    friend class SchedulerClass;
-    friend void task_tramponline();
-
-    Task *next;
-    Task *prev;
-    cont_t context;
-
-
-    bool setup_done = false;
-    unsigned long delay_start = 0;
-    unsigned long delay_ms = 0;
-
-    void loopWrapper() {
-        if (!setup_done) {
-            setup();
-            setup_done = true;
-        }
-
-        while(1) {
-            loop();
-            yield();
-        }
-    }
+ private:
+  bool setup_done;
+  virtual void resume() {
+    if (!setup_done) {
+      setup();
+      setup_done = true;
+    } else if (shouldRun())
+      loop();
+  }
 };
 
 #endif


### PR DESCRIPTION
This PR:
* Removes the main "dummy" task (saves quite some RAM)
* Removed the backwards link in the circular linked list. Instead of this, the call to `begin` stitches the last task to the first one.
* Added LeanTask, which runs in the global context and consumes no RAM
* Added a superclass `ITask` from which both `Task` and `LeanTask` inherit, so that the scheduler doesn't need to care about which kind of task is the current one.
* Documented the new class and its usage.

Caveats of this PR:
* I didn't realise that the version available in the Arduino Library Manager is not the same as the one in github, so this code doesn't build up on the latest commit. (I do not understand what the run groups are in any case.)
* I removed the `if (!setup_done) {` part, as that can run only once in a task. It is suspicious though that you'd have that if it isn't necessary, so please confirm my assumption