### PR TITLE
WDT and network fix

### DIFF
--- a/src/Task.h
+++ b/src/Task.h
@@ -17,6 +17,7 @@ class Task : public AbstractTask {
   }
 
   void yield() override {
+    ::yield();
     cont_suspend(&context);
   }
 


### PR DESCRIPTION
Hi,

I think that before changing the context we should call ::yield() for the network to work correctly. When using WifiManager and Pubsubclient and context switching in tasks with these libraries, I observe memory leaks and heap fragmentation at random times.
I also sometimes see the watchdog timer triggering. This may be due to the network functions.