### PR TITLE
Fixing compilation error when using PlatformIO

### DIFF
--- a/src/LeanTask.h
+++ b/src/LeanTask.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <Arduino.h>
+#include "AbstractTask.h"
 
 class LeanTask : public AbstractTask {
  public:


### PR DESCRIPTION
Hi there!

Thanks for your efforts on creating a proper ESP8266 scheduler. When we tried to use your package in PlatformIO, we received compilation errors regarding the missing `AbstractTask` definition.

We were forced to put `#include <AbstractTask.h>` next to all our `#include <LeanTask.h>` in order for the compiler to be satisfied.

This small and simple fix solves the issue for us, and hopefully does not negatively impact the usage in other compilers.